### PR TITLE
Add RTD integration using conda to have Python3.6

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,12 @@
+name: patapy
+channels:
+ - conda-forge
+ - anaconda
+dependencies:
+ - pip:
+   - sphinx-autodoc-typehints
+   - sphinx-autodoc-annotation
+ - python=3.6
+ - pandas
+ - numpy
+ - statsmodels

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,2 @@
+conda:
+    file: environment.yml


### PR DESCRIPTION
Use the alternative method of getting Python 3.6 to work with RTD, i.e. a conda environment.
This solution was mentioned here: https://github.com/rtfd/readthedocs.org/issues/2581#issuecomment-322044954.