### PR TITLE
Improve handling of GCT files coming from the CCLE

### DIFF
--- a/models.py
+++ b/models.py
@@ -354,15 +354,15 @@ class SampleCollection:
         software.broadinstitute.org/cancer/software/gsea/wiki/index.php/Data_formats
         User is allowed to provide settings different from the standard.
         """
-        version = file_object.readline()
-        rows_count, samples_count = map(int, file_object.readline().split('\t'))
+        version = file_object.readline().rstrip()
+        rows_count, samples_count = map(int, file_object.readline().rstrip().split('\t'))
 
         default_values = {
             'description_column': True,
             'header_line': 2
         }
 
-        if version != '#1.2\n':
+        if version != '#1.2':
             warn('Unsupported version of GCT file')
 
         file_object.seek(0)

--- a/tests/test_models/test_sample_collection.py
+++ b/tests/test_models/test_sample_collection.py
@@ -56,6 +56,17 @@ TP53	na	348.61	172.52	236.45	130.2
 MDM2	na	42.11	55.5	44.81	39.32
 """
 
+# it seems that the GCT files from the Broad Institute's
+# Cancer Cell Line Encyclopedia (CCLE) have an additional
+# tab character at the end of the version and counts lines;
+# this additional tab needs to be handled properly.
+ccle_like_gct = """\
+#1.2	
+1	4	
+NAME	DESCRIPTION	NORM-1	GBM-1	GBM-2	OV-1
+TP53	na	348.61	172.52	236.45	130.2
+"""
+
 
 def test_from_gct():
 
@@ -78,3 +89,8 @@ def test_from_gct():
     with temp_text_file(old_content) as old_gct_file:
         with warns(UserWarning, match='Unsupported version of GCT file'):
             SampleCollection.from_gct_file('Outdated file', old_gct_file)
+
+    with temp_text_file(ccle_like_gct) as gct_file:
+        with warns(None) as warnings:
+            collection = SampleCollection.from_gct_file('all_samples.gct', gct_file)
+        assert not warnings.list


### PR DESCRIPTION
Some Cancer Cell Line Encyclopedia (CCLE) GCT files have additional tab characters at the end of the version
and counts lines; this additional tab needs to be accounted for because:
 - the CCLE is an important database,
 - the file comes from the institution which created the GCT file format (or at least - had significant influence in its adoption), therefore it's likely that other files will have same issue.