### PR TITLE
Fix as_array in SampleCollection, add a test

### DIFF
--- a/models.py
+++ b/models.py
@@ -162,11 +162,11 @@ class SampleCollection:
             for sample in self.samples
         )
 
-    def as_array(self):
+    def as_array(self) -> pd.DataFrame:
         """
         Returns: :class:`pandas.DataFrame` object with data for all samples.
         """
-        return {s.name: pd.DataFrame(s) for s in self.samples}
+        return pd.DataFrame({s.name: s.as_array() for s in self.samples})
 
     def __add__(self, other):
         return SampleCollection(self.name, self.samples + other.samples)

--- a/tests/test_models/test_sample_collection.py
+++ b/tests/test_models/test_sample_collection.py
@@ -25,6 +25,16 @@ def test_init():
     assert sample_collection.name == 'Tumour'
     assert all(isinstance(k, Sample) for k in sample_collection.samples)
 
+    # TODO: this should probably live in a separate file
+    # test as_array
+    df = sample_collection.as_array()
+
+    # two genes
+    assert len(df) == 2
+
+    # two samples
+    assert list(df.columns) == ['Tumour_1', 'Tumour_2']
+
 
 csv_contents = """\
 NAME,NORM-1,GBM-1,GBM-2,OV-1


### PR DESCRIPTION
@sienkie jeżeli już ktoś z Was to poprawił wcześniej (lub już nie zajmujesz się tym projektem), to proszę zignoruj (zamknij) ten PR. W przeciwnym przypadku - na szybko poprawiłem `as_array` i dodałem test bo potrzebowałem wygodnego parsera GCT na już.

W przyszłości, uważam że warto zmienić nazwę na `as_df` lub `as_data_frame` oraz dodać argument `genes_as_str=False`, który byłby przekazywany do `Sample.as_array` (które z kolei powinno nazywać się `Sample.as_series`) 